### PR TITLE
add serialization to cache

### DIFF
--- a/backend/src/utils/cache.ts
+++ b/backend/src/utils/cache.ts
@@ -1,8 +1,19 @@
 import Redis from 'ioredis';
 import config from './config.js';
 
-// Cache configuration constants
-const MEMORY_CACHE_CLEANUP_THRESHOLD = 100; // Trigger cleanup after this many entries
+type CacheValue =
+    | { type: 'null' }
+    | { type: 'undefined' }
+    | { type: 'string'; value: string }
+    | { type: 'number'; value: number }
+    | { type: 'boolean'; value: boolean }
+    | { type: 'date'; value: string }
+    | { type: 'map'; value: [unknown, unknown][] }
+    | { type: 'set'; value: unknown[] }
+    | { type: 'buffer'; value: string }
+    | { type: 'json'; value: unknown };
+
+const UNDEFINED_SENTINEL = Symbol('CACHE_UNDEFINED');
 
 /**
  * Hybrid cache that uses Redis if available, falls back to memory
@@ -12,14 +23,17 @@ class HybridCache {
     private redisClient?: Redis;
     private memoryCache = new Map<string, { value: string; expires: number }>();
     private isRedisAvailable = false;
+    private cleanupThreshold: number;
 
     constructor() {
-        if (config.REDIS_URL) {
+        if (config.REDIS_URL && config.ENABLE_CACHE) {
             this.initRedis(config.REDIS_URL);
         } else {
             this.isRedisAvailable = false;
             console.log('📦 Using in-memory cache (Redis not configured)');
         }
+
+        this.cleanupThreshold = config.CACHE_CLEANUP_THRESHOLD || 100;
     }
 
     private initRedis(url: string) {
@@ -46,11 +60,84 @@ class HybridCache {
         });
     }
 
+    private serializeValue<T>(value: T): string {
+        let payload: CacheValue;
+
+        if (value === null) {
+            payload = { type: 'null' };
+        } else if (value === undefined) {
+            payload = { type: 'undefined' };
+        } else if (typeof value === 'string') {
+            payload = { type: 'string', value };
+        } else if (typeof value === 'number' && Number.isFinite(value)) {
+            payload = { type: 'number', value };
+        } else if (typeof value === 'boolean') {
+            payload = { type: 'boolean', value };
+        } else if (value instanceof Date) {
+            payload = { type: 'date', value: value.toISOString() };
+        } else if (value instanceof Map) {
+            payload = { type: 'map', value: Array.from(value.entries()) };
+        } else if (value instanceof Set) {
+            payload = { type: 'set', value: Array.from(value.values()) };
+        } else if (Buffer.isBuffer(value)) {
+            payload = { type: 'buffer', value: value.toString('base64') };
+        } else {
+            payload = { type: 'json', value };
+        }
+
+        return JSON.stringify(payload);
+    }
+
+    private deserializeValue<T>(raw: string): T | null | typeof UNDEFINED_SENTINEL {
+        try {
+            const payload = JSON.parse(raw) as CacheValue;
+
+            switch (payload.type) {
+                case 'null':
+                    return null;
+                case 'undefined':
+                    return UNDEFINED_SENTINEL;
+                case 'string':
+                    return payload.value as T;
+                case 'number':
+                    return payload.value as T;
+                case 'boolean':
+                    return payload.value as T;
+                case 'date':
+                    return new Date(payload.value) as unknown as T;
+                case 'map':
+                    return new Map(payload.value) as unknown as T;
+                case 'set':
+                    return new Set(payload.value) as unknown as T;
+                case 'buffer':
+                    return Buffer.from(payload.value, 'base64') as unknown as T;
+                case 'json':
+                    return payload.value as T;
+                default:
+                    throw new Error(`Unsupported cache payload type: ${(payload as CacheValue).type}`);
+            }
+        } catch (error) {
+            console.error('Cache deserialization error:', error instanceof Error ? error.message : error);
+            return null;
+        }
+    }
+
+    private unwrapDeserialized<T>(value: T | null | typeof UNDEFINED_SENTINEL): T | null {
+        if (value === UNDEFINED_SENTINEL) {
+            return undefined as T;
+        }
+        return value;
+    }
+
     async get<T>(key: string): Promise<T | null> {
         if (this.isRedisAvailable && this.redisClient) {
             try {
                 const value = await this.redisClient.get(key);
-                return value ? JSON.parse(value) : null;
+                if (value === null) {
+                    return null;
+                }
+                const deserialized = this.deserializeValue<T>(value);
+                return this.unwrapDeserialized(deserialized);
             } catch (error) {
                 console.error('Redis get error:', error instanceof Error ? error.message : error);
                 // Fall through to memory cache
@@ -63,13 +150,17 @@ class HybridCache {
             this.memoryCache.delete(key);
             return null;
         }
-        return JSON.parse(item.value);
+
+        const deserialized = this.deserializeValue<T>(item.value);
+        return this.unwrapDeserialized(deserialized);
     }
 
     async set<T>(key: string, value: T, ttlSeconds: number = 60): Promise<void> {
+        const valueToStoreStr = this.serializeValue(value);
+
         if (this.isRedisAvailable && this.redisClient) {
             try {
-                await this.redisClient.setex(key, ttlSeconds, JSON.stringify(value));
+                await this.redisClient.setex(key, ttlSeconds, valueToStoreStr);
                 return;
             } catch (error) {
                 console.error('Redis set error:', error instanceof Error ? error.message : error);
@@ -79,10 +170,10 @@ class HybridCache {
 
         // Memory cache fallback
         const expires = Date.now() + ttlSeconds * 1000;
-        this.memoryCache.set(key, { value: JSON.stringify(value), expires });
+        this.memoryCache.set(key, { value: valueToStoreStr, expires });
 
         // Clean up expired entries periodically
-        if (this.memoryCache.size > MEMORY_CACHE_CLEANUP_THRESHOLD) {
+        if (this.memoryCache.size > this.cleanupThreshold) {
             this.cleanupMemoryCache();
         }
     }
@@ -100,31 +191,20 @@ class HybridCache {
 // Export singleton instance
 export const cache = new HybridCache();
 
-// Cache key generators
-export const CACHE_KEYS = {
-    VEHICLE_POSITIONS: (routeId: string = 'all') => `bus:${routeId}`,
-    TRIP_UPDATES: (routeId: string = 'all', stopIds?: string[]) =>
-        `trips:${routeId}:${stopIds?.sort().join(',') || 'all'}`,
-    SERVICE_ALERTS: (routeId: string = 'all') => `alerts:${routeId}`,
-};
-
-// Cache TTL in seconds
-export const CACHE_TTL = {
-    VEHICLE_POSITIONS: 10, // 10 seconds (bus positions change frequently)
-    TRIP_UPDATES: 15, // 15 seconds (predictions update regularly)
-    SERVICE_ALERTS: 300, // 5 minutes (alerts rarely change)
-};
-
 /**
  * Helper to get cached value or fetch from factory
  */
 export async function getCachedOrFetch<T>(key: string, fetcher: () => Promise<T>, ttl: number = 60): Promise<T> {
-    const cached = await cache.get<T>(key);
-    if (cached !== null && cached !== undefined) {
-        return cached;
+    if (config.ENABLE_CACHE) {
+        const cached = await cache.get<T>(key);
+        if (cached !== null) {
+            return cached;
+        }
     }
 
     const fresh = await fetcher();
-    await cache.set<T>(key, fresh, ttl);
+    if (config.ENABLE_CACHE) {
+        await cache.set<T>(key, fresh, ttl);
+    }
     return fresh;
 }

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -40,15 +40,16 @@ const envSchema = z.object({
         .enum(['true', 'false'])
         .default('true')
         .transform((val) => val === 'true'),
+    CACHE_TTL_VEHICLE_POSITIONS: z.coerce.number().min(5).max(300).default(10), // seconds
+    CACHE_TTL_PREDICTIONS: z.coerce.number().min(5).max(300).default(15), // seconds
+    CACHE_TTL_SERVICE_ALERTS: z.coerce.number().min(60).max(3600).default(300), // seconds
+    CACHE_TTL_BUS_STOP_PROFILES: z.coerce.number().min(3600).max(604800).default(86400), // seconds
+    CACHE_CLEANUP_THRESHOLD: z.coerce.number().min(50).max(1000).default(100), // Number of items in cache before cleanup is triggered
 
-    // AC Transit API Endpoints
-    AC_TRANSIT_VEHICLE_POSITIONS_URL: z
-        .url()
-        .default('https://api.actransit.org/transit/gtfs-realtime/vehicle-positions'),
-
-    AC_TRANSIT_TRIP_UPDATES_URL: z.url().default('https://api.actransit.org/transit/gtfs-realtime/trip-updates'),
-
-    AC_TRANSIT_SERVICE_ALERTS_URL: z.url().default('https://api.actransit.org/transit/gtfs-realtime/service-alerts'),
+    // AC Transit REST API Base URL
+    AC_TRANSIT_API_BASE_URL: z.url().default('https://api.actransit.org/transit'),
+    ACT_REALTIME_API_BASE_URL: z.url().default('https://api.actransit.org/transit/actrealtime'),
+    GTFS_REALTIME_API_BASE_URL: z.url().default('https://api.actransit.org/transit/gtfsrt'),
 });
 
 /**


### PR DESCRIPTION
This pull request refactors and enhances the caching utility in `backend/src/utils/cache.ts` and updates related configuration in `backend/src/utils/config.ts`. The main improvements include more robust serialization/deserialization for cached values, greater configurability of cache TTLs and cleanup thresholds, and a streamlined approach for cache usage toggling. These changes improve cache reliability, flexibility, and maintainability.

### Caching logic and serialization improvements
* Introduced robust `serializeValue` and `deserializeValue` methods to handle various types (including `Map`, `null`, and `undefined`) for cached data, ensuring consistent storage and retrieval in both Redis and memory cache.
* Updated cache get/set logic to utilize new serialization methods, improving type safety and reducing deserialization errors. [[1]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0L66-R131) [[2]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0L82-R144)

### Configuration and flexibility enhancements
* Replaced hardcoded cache TTLs and cleanup thresholds with environment-configurable values via new config parameters (`CACHE_TTL_*`, `CACHE_CLEANUP_THRESHOLD`), allowing for easier tuning of cache behavior. [[1]](diffhunk://#diff-a21de7e92b2f172725594abdd2f17548e1b51e2a45e21bc9044232fdf684c40aL43-R52) [[2]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0R17-R27)
* Added support for toggling cache usage via the `ENABLE_CACHE` config flag, ensuring cache logic is only active when enabled. [[1]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0L103-R176) [[2]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0R17-R27)

### Codebase simplification
* Removed obsolete cache key generators and TTL constants from `cache.ts`, centralizing configuration in `config.ts` for better maintainability. [[1]](diffhunk://#diff-ec37d6b6e9ac17ee33e98a2ff2aceb99ca2dd40a836e7fd5306cbaee889edee0L103-R176) [[2]](diffhunk://#diff-a21de7e92b2f172725594abdd2f17548e1b51e2a45e21bc9044232fdf684c40aL43-R52)