### PR TITLE
create actRealtime and gtfsRealtime which will replace acTransit service

### DIFF
--- a/backend/src/services/actRealtime.ts
+++ b/backend/src/services/actRealtime.ts
@@ -1,0 +1,432 @@
+import fetch from 'node-fetch';
+import config from '../utils/config.js';
+import { getCachedOrFetch } from '../utils/cache.js';
+
+export type BusStopProfileRaw = {
+    stpid: string; // stop code (5-digit)
+    stpnm: string; // stop name
+    geoid: string; // GTFS stop_id
+    lat: number;
+    lon: number;
+};
+
+/**
+ * Response type for GET actrealtime/stop?rt={rt}&dir={dir}&stpid={stpid}&callback={callback}
+ */
+type BusStopApiResponse = {
+    'bustime-response': {
+        stops: Array<BusStopProfileRaw>;
+    };
+};
+
+export type BusStopPredictionRaw = {
+    tmstmp: string; // "20250918 05:55"
+    typ: string; // "A" for arrival, "D" for departure
+    stpnm: string; // Stop name
+    stpid: string; // Stop ID (5-digit stop code, not GTFS stop_id)
+    vid: string; // Vehicle ID
+    dstp: number; // Distance to stop (in feet)
+    rt: string; // Route (e.g., "51B")
+    rtdd: string; // Route display
+    rtdir: string; // Route direction description
+    des: string; // Destination
+    prdtm: string; // Predicted time "20250918 05:54"
+    tatripid: string; // Trip ID
+    prdctdn: string; // Countdown - "Due" or number of minutes
+    schdtm: string; // Scheduled time
+    seq: number; // Stop sequence
+};
+
+/**
+ * Response type for GET actrealtime/prediction?stpid={stpid}&rt={rt}&vid={vid}&top={top}&tmres={tmres}&callback={callback}&showocprd={showocprd}
+ */
+type BusStopPredictionsResponse = {
+    'bustime-response': {
+        prd: Array<BusStopPredictionRaw>; // Raw prediction objects from ACT API
+    };
+};
+
+type SystemTimeResponse = {
+    'bustime-response'?: {
+        tm?: string;
+    };
+};
+
+export type BusPositionRaw = {
+    vid: string; // Vehicle ID
+    rt: string; // Route (e.g., "51B")
+    des: string; // Destination headsign
+    tmstmp: string; // Timestamp "YYYYMMDD HH:MM"
+    lat: string; // Latitude as a string
+    lon: string; // Longitude as a string
+    hdg?: string; // Heading in degrees
+    pid?: number; // Pattern ID
+    pdist?: number; // Distance travelled along pattern (feet)
+    dly?: boolean; // Delay flag
+    spd?: number; // Speed in mph
+    tablockid?: string; // Block identifier
+    tatripid?: string; // Trip ID (string form)
+    zone?: string; // Fare zone identifier
+    mode?: number; // Mode indicator (0 = bus)
+    psgld?: string; // Passenger load indicator
+    oid?: string; // Operator ID
+    or?: boolean; // Out of route flag
+    blk?: number; // Block number
+    tripid?: number; // Trip identifier (numeric)
+    tripdyn?: number; // Trip dynamics flag
+    rtpidatafeed?: string; // Data feed identifier
+};
+
+/**
+ * Response type for GET actrealtime/vehicle?vid={vid}&rt={rt}&tmres={tmres}&callback={callback}&lat={lat}&lng={lng}&searchRadius={searchRadius}
+ */
+type VehiclePositionsResponse = {
+    'bustime-response'?: {
+        vehicle?: Array<BusPositionRaw>;
+    };
+};
+
+/**
+ * ACT Realtime Service
+ * Handles fetching data from AC Transit's proprietary REST API
+ * This includes stop profiles, predictions, and other real-time data
+ */
+class ACTRealtimeService {
+    private readonly baseUrl: string;
+    private readonly token: string;
+    private readonly busStopProfilePath = '/stop';
+    private readonly busStopPredictionsPath = '/prediction';
+    private readonly vehiclePositionsPath = '/vehicle';
+    private readonly systemTimePath = '/time';
+
+    constructor() {
+        this.baseUrl = config.ACT_REALTIME_API_BASE_URL;
+        this.token = config.AC_TRANSIT_TOKEN;
+    }
+
+    /**
+     * Build URL with token and optional additional parameters
+     * @param baseUrl The base URL to build from
+     * @param params Optional additional query parameters
+     */
+    private buildUrl(baseUrl: string, params?: Record<string, string>): string {
+        const url = new URL(baseUrl);
+
+        // Add token if available
+        if (this.token) {
+            url.searchParams.set('token', this.token);
+        }
+
+        // Add any additional parameters
+        if (params) {
+            Object.entries(params).forEach(([key, value]) => {
+                url.searchParams.set(key, value);
+            });
+        }
+
+        return url.toString();
+    }
+
+    /**
+     * Fetch bus stop profiles from stop codes using AC Transit REST API batch endpoint (raw, no caching)
+     * @param stopCodes Array of 5-digit stop codes (max 10 per request)
+     * @returns Map of stop_code to BusStopProfileRaw
+     */
+    private async fetchBusStopProfilesRaw(stopCodes: string[]): Promise<Map<string, BusStopProfileRaw>> {
+        const profileMap = new Map<string, BusStopProfileRaw>();
+
+        if (stopCodes.length === 0) {
+            return profileMap;
+        }
+
+        // AC Transit API supports up to 10 stop codes per request
+        if (stopCodes.length > 10) {
+            throw new Error('AC Transit API supports maximum 10 stop codes per request');
+        }
+
+        try {
+            // Join stop codes with comma for batch request
+            const url = `${this.baseUrl}${this.busStopProfilePath}`;
+            const params = { stpid: stopCodes.join(',') };
+            const finalUrl = this.buildUrl(url, params);
+
+            const response = await fetch(finalUrl, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                if (response.status === 404) {
+                    console.warn(`Stop codes not found: ${stopCodes.join(', ')}`);
+                    return profileMap;
+                }
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data: BusStopApiResponse = (await response.json()) as BusStopApiResponse;
+
+            // Navigate through the nested response structure
+            const stops = data?.['bustime-response']?.stops;
+            if (!stops || stops.length === 0) {
+                console.warn(`No stops found for codes: ${stopCodes.join(', ')}`);
+                return profileMap;
+            }
+
+            stopCodes.forEach((stopCode) => {
+                const profile = stops.find((stop) => stop.stpid === stopCode);
+                if (profile) {
+                    profileMap.set(stopCode, profile);
+                }
+            });
+
+            // Log any stop codes that weren't found
+            const missingCodes = stopCodes.filter((code) => !profileMap.has(code));
+            if (missingCodes.length > 0) {
+                console.warn(`Stop codes not found in response: ${missingCodes.join(', ')}`);
+            }
+
+            return profileMap;
+        } catch (error) {
+            console.error(`Error fetching bus stop profiles for stop codes ${stopCodes.join(', ')}:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Fetch bus stop profiles for multiple stop codes with caching and batching
+     * @param stopCodes Array of 5-digit stop codes
+     * @returns Map of stop_code to BusStopProfile
+     */
+    async fetchBusStopProfiles(stopCodes: string[]): Promise<Map<string, BusStopProfileRaw>> {
+        const profileMap = new Map<string, BusStopProfileRaw>();
+
+        if (stopCodes.length === 0) {
+            return profileMap;
+        }
+
+        // Split into chunks of 10 (AC Transit API limit) using array methods
+        const chunkSize = 10;
+        const chunks = Array.from({ length: Math.ceil(stopCodes.length / chunkSize) }, (_, index) =>
+            stopCodes.slice(index * chunkSize, (index + 1) * chunkSize)
+        );
+
+        // Process chunks in parallel with caching
+        const promises = chunks.map(async (chunk) => {
+            // Create a cache key for this batch
+            const cacheKey = `bus-stop-profiles:${chunk.sort().join(',')}`;
+
+            try {
+                const chunkMap = await getCachedOrFetch(
+                    cacheKey,
+                    () => this.fetchBusStopProfilesRaw(chunk),
+                    config.CACHE_TTL_BUS_STOP_PROFILES
+                );
+
+                // Merge results into main map using forEach
+                if (chunkMap.size > 0) {
+                    chunkMap.forEach((profile, code) => profileMap.set(code, profile));
+                }
+            } catch (error) {
+                console.error(`Failed to fetch bus stop profiles for chunk: ${chunk.join(', ')}`, error);
+            }
+        });
+
+        await Promise.all(promises);
+
+        // Log any stop codes that weren't found
+        const missingCodes = stopCodes.filter((code) => !profileMap.has(code));
+        if (missingCodes.length > 0) {
+            console.warn(`Could not find bus stop profiles for codes: ${missingCodes.join(', ')}`);
+        }
+
+        return profileMap;
+    }
+
+    /**
+     * Fetch predictions for multiple stops from AC Transit REST API (raw, no caching)
+     * @param stopCodes Array of 5-digit stop codes (max 10 per request)
+     * @returns Map of stop_code to predictions response
+     */
+    private async fetchBusStopPredictionsRaw(stopCodes: string[]): Promise<Map<string, Array<BusStopPredictionRaw>>> {
+        const predictionsMap = new Map<string, Array<BusStopPredictionRaw>>();
+
+        if (stopCodes.length === 0) {
+            return predictionsMap;
+        }
+
+        // AC Transit API supports up to 10 stop codes per request
+        if (stopCodes.length > 10) {
+            throw new Error('AC Transit API supports maximum 10 stop codes per request');
+        }
+
+        try {
+            // Join stop codes with comma for batch request
+            // Note: AC Transit confusingly calls stop_code "stpid"
+            const url = `${this.baseUrl}${this.busStopPredictionsPath}`;
+            const params = { stpid: stopCodes.join(',') };
+            const finalUrl = this.buildUrl(url, params);
+
+            const response = await fetch(finalUrl, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                if (response.status === 404) {
+                    console.warn(`No predictions for stop codes: ${stopCodes.join(', ')}`);
+                    return predictionsMap;
+                }
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data: BusStopPredictionsResponse = (await response.json()) as BusStopPredictionsResponse;
+
+            if (data) {
+                const predictions = data['bustime-response']?.prd;
+                stopCodes.forEach((stopCode) => {
+                    predictionsMap.set(
+                        stopCode,
+                        predictions && Array.isArray(predictions) ? predictions.filter((p) => p.stpid === stopCode) : []
+                    );
+                });
+            }
+
+            return predictionsMap;
+        } catch (error) {
+            console.error(`Error fetching predictions for stop codes ${stopCodes.join(', ')}:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Fetch predictions for multiple stops with caching and batching
+     * @param stopCodes Array of 5-digit stop codes
+     * @returns Map of stop_code to predictions response
+     */
+    async fetchBusStopPredictions(stopCodes: string[]): Promise<Map<string, Array<BusStopPredictionRaw>>> {
+        const predictionsMap = new Map<string, Array<BusStopPredictionRaw>>();
+
+        if (stopCodes.length === 0) {
+            return predictionsMap;
+        }
+
+        // Split into chunks of 10 (AC Transit API limit)
+        const chunkSize = 10;
+        const chunks = Array.from({ length: Math.ceil(stopCodes.length / chunkSize) }, (_, index) =>
+            stopCodes.slice(index * chunkSize, (index + 1) * chunkSize)
+        );
+
+        // Process chunks in parallel with caching
+        const promises = chunks.map(async (chunk) => {
+            const cacheKey = `bus-stop-predictions:${chunk.sort().join(',')}`;
+
+            try {
+                const chunkMap = await getCachedOrFetch(
+                    cacheKey,
+                    () => this.fetchBusStopPredictionsRaw(chunk),
+                    config.CACHE_TTL_PREDICTIONS
+                );
+
+                // Merge results into main map
+                chunkMap.forEach((predictions, code) => predictionsMap.set(code, predictions));
+            } catch (error) {
+                console.error(`Failed to fetch predictions for chunk: ${chunk.join(', ')}`, error);
+            }
+        });
+
+        await Promise.all(promises);
+
+        return predictionsMap;
+    }
+
+    /**
+     * Fetch the current AC Transit system time without caching
+     */
+    async fetchSystemTime(): Promise<Date> {
+        const url = `${this.baseUrl}${this.systemTimePath}`;
+        const finalUrl = this.buildUrl(url, { unixTime: 'true' });
+
+        const response = await fetch(finalUrl, {
+            headers: {
+                Accept: 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error fetching system time! status: ${response.status}`);
+        }
+
+        const data: SystemTimeResponse = (await response.json()) as SystemTimeResponse;
+        const rawTimestamp = data?.['bustime-response']?.tm;
+
+        if (!rawTimestamp) {
+            throw new Error('AC Transit system time response missing timestamp');
+        }
+
+        const timestampMs = Number.parseInt(rawTimestamp, 10);
+
+        if (Number.isNaN(timestampMs)) {
+            throw new Error(`Invalid AC Transit system time value: ${rawTimestamp}`);
+        }
+
+        return new Date(timestampMs);
+    }
+
+    /**
+     * Fetch vehicle positions (raw, no caching)
+     * @param routeId Optional route ID to filter by
+     * @returns Array of BusPositionRaw
+     */
+    private async fetchBusPositionsRaw(routeId?: string): Promise<Array<BusPositionRaw>> {
+        try {
+            const url = `${this.baseUrl}${this.vehiclePositionsPath}`;
+            const finalUrl = this.buildUrl(url, routeId ? { rt: routeId } : undefined);
+
+            const response = await fetch(finalUrl, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            if (!response.ok) {
+                if (response.status === 404) {
+                    console.warn(`No vehicle positions found${routeId ? ` for route: ${routeId}` : ''}`);
+                    return [];
+                }
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data: VehiclePositionsResponse = (await response.json()) as VehiclePositionsResponse;
+            const vehicles = data?.['bustime-response']?.vehicle;
+
+            if (!vehicles || vehicles.length === 0) {
+                return [];
+            }
+
+            return vehicles;
+        } catch (error) {
+            console.error(`Error fetching vehicle positions${routeId ? ` for route ${routeId}` : ''}:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Fetch vehicle positions with caching
+     * @param routeId Optional route ID to filter by
+     * @returns Array of BusPositionRaw
+     */
+    async fetchVehiclePositions(routeId?: string): Promise<Array<BusPositionRaw>> {
+        const cacheKey = `vehicle-positions:${routeId ?? 'all'}`;
+
+        return getCachedOrFetch(cacheKey, () => this.fetchBusPositionsRaw(routeId), config.CACHE_TTL_VEHICLE_POSITIONS);
+    }
+}
+
+// Export singleton instance
+const actRealtimeService = new ACTRealtimeService();
+
+export type ACTRealtimeServiceType = typeof actRealtimeService;
+
+export default actRealtimeService;

--- a/backend/src/services/gtfsRealtime.ts
+++ b/backend/src/services/gtfsRealtime.ts
@@ -1,0 +1,223 @@
+import fetch from 'node-fetch';
+import GtfsRealtimeBindings, { type transit_realtime } from 'gtfs-realtime-bindings';
+
+import config from '../utils/config.js';
+import { getCachedOrFetch } from '../utils/cache.js';
+
+// Use the protobuf decoder from the default export
+const { transit_realtime: rt } = GtfsRealtimeBindings;
+const { FeedMessage } = rt;
+
+type IFeedMessage = transit_realtime.IFeedMessage;
+
+/**
+ * GTFS Realtime Service
+ * Handles fetching and parsing GTFS-Realtime protocol buffer feeds from AC Transit
+ */
+class GTFSRealtimeService {
+    private readonly baseUrl: string;
+    private readonly token: string;
+    private readonly vehiclePositionsPath = '/vehicles';
+    private readonly tripUpdatesPath = '/tripupdates';
+    private readonly serviceAlertsPath = '/alerts';
+
+    constructor() {
+        this.baseUrl = config.GTFS_REALTIME_API_BASE_URL;
+        this.token = config.AC_TRANSIT_TOKEN;
+    }
+
+    /**
+     * Build URL with token and optional additional parameters
+     * @param baseUrl The base URL to build from
+     * @param params Optional additional query parameters
+     */
+    private buildUrl(baseUrl: string, params?: Record<string, string>): string {
+        const url = new URL(baseUrl);
+
+        // Add token if available
+        if (this.token) {
+            url.searchParams.set('token', this.token);
+        }
+
+        // Add any additional parameters
+        if (params) {
+            Object.entries(params).forEach(([key, value]) => {
+                url.searchParams.set(key, value);
+            });
+        }
+
+        return url.toString();
+    }
+
+    /**
+     * Fetch and parse GTFS-Realtime feed
+     */
+    private async fetchGTFSFeed(url: string, params?: Record<string, string>): Promise<IFeedMessage> {
+        try {
+            const finalUrl = this.buildUrl(url, params);
+            const response = await fetch(finalUrl);
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            // Get the response as a buffer (binary data)
+            const buffer = await response.arrayBuffer();
+            const uint8Array = new Uint8Array(buffer);
+
+            // Parse the protobuf data
+            const feed = FeedMessage.decode(uint8Array);
+
+            return feed;
+        } catch (error) {
+            console.error(`Error fetching GTFS feed from ${url}:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Fetch vehicle positions for all AC Transit buses (raw feed, uncached)
+     */
+    private async fetchVehiclePositionsRaw(): Promise<IFeedMessage> {
+        const url = `${this.baseUrl}${this.vehiclePositionsPath}`;
+        const feed = await this.fetchGTFSFeed(url);
+        return feed;
+    }
+
+    /**
+     * Fetch vehicle positions with caching
+     * Cache key includes 'all' since this fetches all routes
+     */
+    async fetchVehiclePositions(): Promise<IFeedMessage> {
+        // Use cache for all vehicle positions
+        return getCachedOrFetch(`bus:all`, () => this.fetchVehiclePositionsRaw(), config.CACHE_TTL_VEHICLE_POSITIONS);
+    }
+
+    /**
+     * Fetch vehicle positions for a specific route with caching
+     */
+    async fetchVehiclePositionsForRoute(routeId: string): Promise<IFeedMessage> {
+        // Get all positions (will use cache if available)
+        const allPositions = await this.fetchVehiclePositions();
+
+        // Filter for the specific route
+        return this.filterByRoute(allPositions, routeId);
+    }
+
+    /**
+     * Fetch trip updates (arrival predictions) - raw, uncached
+     */
+    private async fetchTripUpdatesRaw(): Promise<IFeedMessage> {
+        const url = `${this.baseUrl}${this.tripUpdatesPath}`;
+        const feed = await this.fetchGTFSFeed(url);
+        return feed;
+    }
+
+    /**
+     * Fetch trip updates with caching
+     */
+    async fetchTripUpdates(): Promise<IFeedMessage> {
+        return getCachedOrFetch(`trips:all`, () => this.fetchTripUpdatesRaw(), config.CACHE_TTL_PREDICTIONS);
+    }
+
+    /**
+     * Fetch trip updates for a specific route with caching
+     * Optionally filter by stop ID when provided
+     */
+    async fetchTripUpdatesForRoute(routeId: string, stopId?: string): Promise<IFeedMessage> {
+        // Get all trip updates (will use cache if available)
+        const allUpdates = await this.fetchTripUpdates();
+
+        // Filter for the specific route first
+        const routeFiltered = this.filterByRoute(allUpdates, routeId);
+
+        // Optionally filter by stop ID within the trip updates
+        if (!stopId) {
+            return routeFiltered;
+        }
+
+        const entities = routeFiltered.entity || [];
+        const filteredEntities = entities
+            .map((entity) => {
+                return {
+                    ...entity,
+                    tripUpdate: entity.tripUpdate
+                        ? {
+                              ...entity.tripUpdate,
+                              stopTimeUpdate:
+                                  entity.tripUpdate.stopTimeUpdate?.filter((stu) => stu.stopId === stopId) || [],
+                          }
+                        : undefined,
+                };
+            })
+            .filter(
+                (entity) =>
+                    entity.tripUpdate && entity.tripUpdate.stopTimeUpdate && entity.tripUpdate.stopTimeUpdate.length > 0
+            );
+
+        return {
+            ...routeFiltered,
+            entity: filteredEntities,
+        };
+    }
+
+    /**
+     * Fetch service alerts - raw, uncached
+     */
+    private async fetchServiceAlertsRaw(): Promise<IFeedMessage> {
+        const url = `${this.baseUrl}${this.serviceAlertsPath}`;
+        const feed = await this.fetchGTFSFeed(url);
+        return feed;
+    }
+
+    /**
+     * Fetch service alerts with caching
+     */
+    async fetchServiceAlerts(): Promise<IFeedMessage> {
+        return getCachedOrFetch(`alerts:all`, () => this.fetchServiceAlertsRaw(), config.CACHE_TTL_SERVICE_ALERTS);
+    }
+
+    /**
+     * Fetch service alerts for a specific route with caching
+     */
+    async fetchServiceAlertsForRoute(routeId: string): Promise<IFeedMessage> {
+        // Get all alerts (will use cache if available)
+        const allAlerts = await this.fetchServiceAlerts();
+
+        // Filter for the specific route
+        return this.filterByRoute(allAlerts, routeId);
+    }
+
+    /**
+     * Filter data for specific route (e.g., '51B')
+     */
+    filterByRoute(feed: IFeedMessage, routeId: string): IFeedMessage {
+        const filteredEntities = (feed.entity || []).filter((entity) => {
+            // Check vehicle positions
+            if (entity.vehicle?.trip?.routeId === routeId) {
+                return true;
+            }
+            // Check trip updates
+            if (entity.tripUpdate?.trip.routeId === routeId) {
+                return true;
+            }
+            // Check alerts
+            if (entity.alert?.informedEntity?.some((e) => e.routeId === routeId)) {
+                return true;
+            }
+            return false;
+        });
+
+        return {
+            ...feed,
+            entity: filteredEntities,
+        };
+    }
+}
+
+// Export singleton instance
+const gtfsRealtimeService = new GTFSRealtimeService();
+
+export type GTFSRealtimeServiceType = typeof gtfsRealtimeService;
+
+export default gtfsRealtimeService;


### PR DESCRIPTION
This pull request introduces a new GTFS Realtime service to the backend, providing a unified way to fetch, cache, and filter AC Transit GTFS-Realtime feeds for vehicle positions, trip updates, and service alerts. The service supports both raw and cached data retrieval, and enables filtering by route and stop. This change centralizes GTFS-Realtime logic, improves maintainability, and enhances performance through caching.

**New GTFS Realtime service implementation:**

* Added `GTFSRealtimeService` class in `backend/src/services/gtfsRealtime.ts` to handle fetching, parsing, and filtering GTFS-Realtime protocol buffer feeds from AC Transit.
* Integrated caching for vehicle positions, trip updates, and service alerts using `getCachedOrFetch`, with configurable TTL values.
* Implemented filtering methods to retrieve feed data for a specific route and, for trip updates, an optional stop ID.
* Provided a singleton export of the service for use throughout the backend.