### PR TITLE
add shimmer to system time component

### DIFF
--- a/frontend/src/components/SystemTime.tsx
+++ b/frontend/src/components/SystemTime.tsx
@@ -12,7 +12,7 @@ type SystemTimePayload = {
 };
 
 export function SystemTimeCard() {
-    const [{ data, fetching, error }] = useSubscription<SystemTimePayload>({
+    const [{ data, error }] = useSubscription<SystemTimePayload>({
         query: SYSTEM_TIME_SUBSCRIPTION,
     });
 
@@ -77,16 +77,11 @@ export function SystemTimeCard() {
         });
     }, [displayTime]);
 
-    const createSyncStatusText = (): string | null => {
-        if (!lastSyncAt) {
-            return null;
-        }
-
+    let syncStatus: string | null = null;
+    if (lastSyncAt) {
         const deltaSeconds = Math.max(0, Math.round((Date.now() - lastSyncAt) / 1000));
-        return deltaSeconds <= 1 ? 'Synced just now' : `Synced ${deltaSeconds} seconds ago`;
-    };
-
-    const syncStatus = createSyncStatusText();
+        syncStatus = deltaSeconds <= 1 ? 'Synced just now' : `Synced ${deltaSeconds} seconds ago`;
+    }
 
     if (error) {
         return (
@@ -100,11 +95,21 @@ export function SystemTimeCard() {
     return (
         <div className="rounded-xl border border-slate-800 bg-slate-900/80 p-6">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Live system clock</p>
-            <p className="mt-3 text-4xl font-mono">
-                {formattedClockTime ?? (fetching ? 'Connecting…' : 'Waiting for system time…')}
-            </p>
-            {formattedDate ? <p className="mt-2 text-sm text-slate-400">{formattedDate}</p> : null}
-            {syncStatus ? <p className="mt-4 text-xs uppercase tracking-[0.2em] text-slate-500">{syncStatus}</p> : null}
+            <div className="mt-3 h-12 font-mono text-4xl">
+                {formattedClockTime ? (
+                    <p>{formattedClockTime}</p>
+                ) : (
+                    <div className="h-full w-3/4 rounded-md shimmer" aria-hidden />
+                )}
+            </div>
+            <div className="mt-2 min-h-5 text-sm text-slate-400">
+                {formattedDate ? <p>{formattedDate}</p> : <div className="h-5 w-2/3 rounded-md shimmer" aria-hidden />}
+            </div>
+            {syncStatus ? (
+                <p className="mt-4 text-xs uppercase tracking-[0.2em] text-slate-500">{syncStatus}</p>
+            ) : (
+                <div className="mt-4 h-3 w-1/3 rounded-md shimmer" aria-hidden />
+            )}
         </div>
     );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,26 @@
         @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
     }
 }
+
+@layer utilities {
+    .shimmer {
+        position: relative;
+        overflow: hidden;
+        background-color: rgb(30 41 59 / 0.6);
+    }
+
+    .shimmer::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        transform: translateX(-100%);
+        background-image: linear-gradient(90deg, transparent, rgb(148 163 184 / 0.35), transparent);
+        animation: shimmer-slide 1.5s infinite;
+    }
+}
+
+@keyframes shimmer-slide {
+    100% {
+        transform: translateX(100%);
+    }
+}


### PR DESCRIPTION
This pull request improves the user experience of the `SystemTimeCard` component by adding loading placeholders (shimmer effects) for the clock, date, and sync status while data is loading. It also simplifies the sync status logic and removes unused state. The most important changes are grouped below:

**UI/UX Improvements:**

* Added shimmer loading placeholders for the clock, date, and sync status in `SystemTimeCard` to provide visual feedback while data is loading. (`frontend/src/components/SystemTime.tsx`)
* Implemented a reusable `.shimmer` utility class and keyframes in `index.css` to support the shimmer effect for loading states. (`frontend/src/index.css`)

**Code Simplification:**

* Removed the unused `fetching` variable from the subscription hook and related conditional rendering. (`frontend/src/components/SystemTime.tsx`)
* Refactored sync status logic by replacing the `createSyncStatusText` function with a direct assignment, simplifying the code. (`frontend/src/components/SystemTime.tsx`)