### PR TITLE
add predictions card

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import BusStopPredictionsCard from './components/BusStopPredictionsCard';
 import SystemTimeCard from './components/SystemTimeCard';
 
 function App() {
@@ -5,12 +6,12 @@ function App() {
         <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
             <section className="w-full max-w-md space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-8 shadow-2xl shadow-slate-950/60 backdrop-blur">
                 <header className="space-y-2">
-                    <p className="text-sm uppercase tracking-[0.4em] text-slate-400">Dashboard</p>
-                    <h1 className="text-3xl font-semibold tracking-tight">Where is 51B</h1>
-                    <p className="text-sm text-slate-400">Monitoring AC Transit system updates in real time.</p>
+                    <p className="text-sm uppercase tracking-[0.4em] text-slate-200">Where is 51B?</p>
                 </header>
 
                 <SystemTimeCard />
+                <BusStopPredictionsCard routeId="51B" direction="INBOUND" stopCode="58883" />
+                <BusStopPredictionsCard routeId="51B" direction="OUTBOUND" stopCode="55559" />
             </section>
         </main>
     );

--- a/frontend/src/components/BusStopPredictionsCard.tsx
+++ b/frontend/src/components/BusStopPredictionsCard.tsx
@@ -1,0 +1,153 @@
+import { gql, useSubscription } from 'urql';
+
+const BUS_STOP_PREDICTIONS_SUBSCRIPTION = gql`
+    subscription BusStopPredictions($routeId: String!, $direction: BusDirection!, $stopCode: String!) {
+        busStopPredictions(routeId: $routeId, direction: $direction, stopCode: $stopCode) {
+            vehicleId
+            tripId
+            arrivalTime
+            departureTime
+            minutesAway
+            isOutbound
+            distanceToStopFeet
+        }
+    }
+`;
+
+type BusStopPrediction = {
+    vehicleId: string;
+    tripId: string;
+    arrivalTime: string;
+    departureTime: string;
+    minutesAway: number;
+    isOutbound: boolean;
+    distanceToStopFeet: number | null;
+};
+
+type BusStopPredictionsPayload = {
+    busStopPredictions: BusStopPrediction[];
+};
+
+type BusDirection = 'INBOUND' | 'OUTBOUND';
+
+type BusStopPredictionsCardProps = {
+    routeId: string;
+    direction: BusDirection;
+    stopCode: string;
+};
+
+function formatClockTime(isoString: string) {
+    const dateTime = new Date(isoString);
+    if (Number.isNaN(dateTime.getTime())) {
+        return '—';
+    }
+
+    return dateTime.toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+function formatDistance(feet: number | null) {
+    if (feet === null) {
+        return null;
+    }
+
+    if (feet < 1000) {
+        return `${feet.toLocaleString()} ft away`;
+    }
+
+    const miles = feet / 5280;
+    const rounded = Math.max(0.1, Math.round(miles * 10) / 10);
+    return `${rounded.toFixed(1)} mi away`;
+}
+
+function BusStopPredictionsCard({ routeId, direction, stopCode }: BusStopPredictionsCardProps) {
+    const [{ data, error, fetching }] = useSubscription<BusStopPredictionsPayload>({
+        query: BUS_STOP_PREDICTIONS_SUBSCRIPTION,
+        variables: {
+            routeId,
+            direction,
+            stopCode,
+        },
+    });
+
+    const predictions = data?.busStopPredictions ?? [];
+    const isLoading = fetching && !data;
+    const directionLabel = direction === 'INBOUND' ? 'Inbound' : 'Outbound';
+
+    const accessibilityProps = isLoading
+        ? {
+              role: 'status' as const,
+              'aria-live': 'polite' as const,
+              'aria-busy': 'true' as const,
+          }
+        : {};
+
+    return (
+        <section
+            className="rounded-xl border border-slate-800 bg-slate-900/80 p-6"
+            aria-label={`${directionLabel} arrivals for route ${routeId} at stop ${stopCode}`}
+            {...accessibilityProps}
+        >
+            <header className="flex flex-wrap items-baseline justify-between gap-2">
+                <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+                        {stopCode} - {directionLabel} arrivals
+                    </p>
+                </div>
+            </header>
+
+            {error ? (
+                <div
+                    className="mt-4 rounded-lg border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-200"
+                    role="alert"
+                >
+                    <p className="font-medium">Subscription error</p>
+                    <p>{error.message}</p>
+                </div>
+            ) : null}
+
+            <div className="mt-4 space-y-3">
+                {isLoading ? (
+                    <>
+                        <div className="h-16 w-full rounded-lg shimmer" aria-hidden="true" />
+                        <div className="h-16 w-full rounded-lg shimmer" aria-hidden="true" />
+                        <span className="sr-only">Loading predicted arrivals</span>
+                    </>
+                ) : null}
+
+                {!isLoading && predictions.length === 0 ? (
+                    <p className="text-sm text-slate-400">No upcoming arrivals are available right now.</p>
+                ) : null}
+
+                {!isLoading && predictions.length > 0
+                    ? predictions.map((prediction) => {
+                          const minutesAway = Math.max(0, prediction.minutesAway);
+                          const formattedArrival = formatClockTime(prediction.arrivalTime);
+                          const distance = formatDistance(prediction.distanceToStopFeet);
+
+                          return (
+                              <article
+                                  key={`${prediction.tripId}-${prediction.vehicleId}-${prediction.arrivalTime}`}
+                                  className="flex items-center justify-between rounded-xl border border-slate-800/70 bg-slate-900/60 px-4 py-3"
+                              >
+                                  <div>
+                                      <p className="text-2xl font-semibold text-slate-100">{minutesAway} min</p>
+                                      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Until arrival</p>
+                                  </div>
+                                  <div className="text-right text-sm text-slate-300">
+                                      <p className="font-medium">Vehicle {prediction.vehicleId || '?'}</p>
+                                      <p className="text-slate-400">ETA {formattedArrival}</p>
+                                      {distance ? <p className="text-xs text-slate-500">{distance}</p> : null}
+                                  </div>
+                              </article>
+                          );
+                      })
+                    : null}
+            </div>
+        </section>
+    );
+}
+
+export default BusStopPredictionsCard;


### PR DESCRIPTION
This pull request introduces a new `BusStopPredictionsCard` component to the frontend and integrates it into the dashboard, enabling real-time display of bus arrival predictions for specific stops and directions. The changes enhance the dashboard by showing inbound and outbound arrival information for route 51B, leveraging GraphQL subscriptions for live updates.

### Dashboard UI enhancements

* Added the `BusStopPredictionsCard` component to the dashboard in `App.tsx`, displaying real-time inbound and outbound arrival predictions for route 51B at stops 58883 and 55559.
* Updated the dashboard header to clarify its focus on the 51B route, improving user clarity.

### Real-time bus predictions feature

* Implemented the new `BusStopPredictionsCard` component, which subscribes to bus stop prediction updates via GraphQL, displays loading and error states, and formats arrival times and distances for user-friendly presentation.
* Defined supporting types, formatting utilities, and UI logic in `BusStopPredictionsCard.tsx` to ensure robust and accessible display of prediction data.

<img width="573" height="892" alt="image" src="https://github.com/user-attachments/assets/c5e4595a-1d92-4491-bc82-4dcd7fa69507" />
