### PR TITLE
filter out predictions with no vehicle ids

### DIFF
--- a/backend/src/formatters/busStopPrediction.ts
+++ b/backend/src/formatters/busStopPrediction.ts
@@ -43,7 +43,9 @@ export function createBusStopPredictionsFromActRealtime(
     }
 
     return rawPredictions
-        .filter((prediction) => isOutboundDirection(prediction.rtdir) === isOutbound)
+        .filter(
+            (prediction) => isOutboundDirection(prediction.rtdir) === isOutbound && prediction.prdtm && prediction.vid
+        )
         .map((prediction) => {
             const arrivalTime = parseActRealtimeTimestamp(prediction.prdtm);
             const minutesAway = parseMinutesAway(prediction.prdctdn);
@@ -69,12 +71,15 @@ export function createBusStopPredictionsFromGtfsFeed(
 
     // Flatten all stop time updates with their trip context
     const allStopUpdates: BusStopPrediction[] = feedMessage.entity
-        .filter((entity) => entity.tripUpdate?.trip?.routeId && entity.tripUpdate?.stopTimeUpdate)
+        .filter(
+            (entity) =>
+                entity.tripUpdate?.trip?.routeId && entity.tripUpdate?.stopTimeUpdate && entity.tripUpdate?.vehicle?.id
+        )
         .flatMap((entity) => {
             const tripUpdate = entity.tripUpdate!;
             const trip = tripUpdate.trip;
             const tripIsOutbound = trip.directionId === 1; // GTFS directionId: 1=outbound (Amtrak), 0=inbound (Rockridge BART)
-            const vehicleId = tripUpdate.vehicle?.id || entity.id || 'unknown';
+            const vehicleId = tripUpdate.vehicle!.id as string;
 
             return tripUpdate
                 .stopTimeUpdate!.filter(


### PR DESCRIPTION
This pull request improves the reliability of bus stop prediction data by ensuring that only predictions with valid vehicle and arrival time information are included. The changes add stricter filtering to both ACT Realtime and GTFS feed processing functions, which helps prevent incomplete or inaccurate predictions from being returned.

Filtering enhancements for prediction validity:

* [`backend/src/formatters/busStopPrediction.ts`](diffhunk://#diff-9a78c725f900da74caedffc21d21cebb80fb4e443e84be208401a0bca5e5644dL46-R48): In `createBusStopPredictionsFromActRealtime`, predictions are now filtered to require both a valid arrival time (`prdtm`) and vehicle ID (`vid`), in addition to matching the direction.
* [`backend/src/formatters/busStopPrediction.ts`](diffhunk://#diff-9a78c725f900da74caedffc21d21cebb80fb4e443e84be208401a0bca5e5644dL72-R82): In `createBusStopPredictionsFromGtfsFeed`, entities are now filtered to require a valid vehicle ID, ensuring that only predictions with vehicle context are processed.