### PR TITLE
add bus stop header to prediction cards

### DIFF
--- a/frontend/src/components/BusStopCardHeader.tsx
+++ b/frontend/src/components/BusStopCardHeader.tsx
@@ -1,0 +1,90 @@
+import { gql, useQuery } from 'urql';
+
+const BUS_STOP_CARD_HEADER_QUERY = gql`
+    query BusStopCardHeader($busStopCode: String!) {
+        busStop(busStopCode: $busStopCode) {
+            code
+            name
+        }
+    }
+`;
+
+type BusStopCardHeaderProps = {
+    busStopCode: string;
+};
+
+type BusStopCardHeaderData = {
+    busStop: {
+        code: string;
+        name: string;
+    } | null;
+};
+
+// Matches a bus stop name followed by parenthetical content, e.g. 'Shattuck Sq & Center St (Downtown Berkeley BART)'
+const BUS_STOP_NAME_WITH_PARENTHETICAL_REGEX = /^(.*?)(\s*\(([^()]+)\))$/;
+
+function splitBusStopName(name: string) {
+    const trimmed = name.trim();
+    const match = trimmed.match(BUS_STOP_NAME_WITH_PARENTHETICAL_REGEX);
+
+    if (!match) {
+        return { main: trimmed, parenthetical: null };
+    }
+
+    const main = match[1].trim();
+    const parenthetical = match[3].trim();
+
+    if (!main) {
+        return { main: trimmed, parenthetical: null };
+    }
+
+    return { main, parenthetical };
+}
+
+function BusStopCardHeader({ busStopCode }: BusStopCardHeaderProps) {
+    const [{ data, fetching, error }] = useQuery<BusStopCardHeaderData>({
+        query: BUS_STOP_CARD_HEADER_QUERY,
+        variables: { busStopCode },
+    });
+
+    const busStop = data?.busStop;
+    const showSkeleton = fetching && !busStop;
+    const stopCode = busStop?.code ?? busStopCode;
+    const nameParts = busStop?.name ? splitBusStopName(busStop.name) : null;
+
+    return (
+        <header className="flex flex-col gap-2">
+            {showSkeleton ? (
+                <>
+                    <div className="h-3 w-24 rounded-sm shimmer" aria-hidden="true" />
+                    <div className="h-6 w-48 rounded-md shimmer" aria-hidden="true" />
+                    <div className="h-4 w-40 rounded-sm shimmer" aria-hidden="true" />
+                    <span className="sr-only">Loading bus stop details</span>
+                </>
+            ) : (
+                <>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                        Bus Stop {stopCode}
+                    </p>
+                    {nameParts ? (
+                        <>
+                            <h2 className="text-xl font-semibold leading-tight text-slate-100">{nameParts.main}</h2>
+                            {nameParts.parenthetical ? (
+                                <p className="text-slate-300">({nameParts.parenthetical})</p>
+                            ) : null}
+                        </>
+                    ) : (
+                        <h2 className="text-xl font-semibold text-slate-100 leading-tight">
+                            Bus stop {stopCode} details unavailable
+                        </h2>
+                    )}
+                    {error && !busStop ? (
+                        <p className="text-xs text-red-300">Unable to load bus stop information.</p>
+                    ) : null}
+                </>
+            )}
+        </header>
+    );
+}
+
+export default BusStopCardHeader;

--- a/frontend/src/components/BusStopPredictionsCard.tsx
+++ b/frontend/src/components/BusStopPredictionsCard.tsx
@@ -1,5 +1,7 @@
 import { gql, useSubscription } from 'urql';
 
+import BusStopCardHeader from './BusStopCardHeader';
+
 const BUS_STOP_PREDICTIONS_SUBSCRIPTION = gql`
     subscription BusStopPredictions($routeId: String!, $direction: BusDirection!, $stopCode: String!) {
         busStopPredictions(routeId: $routeId, direction: $direction, stopCode: $stopCode) {
@@ -90,13 +92,10 @@ function BusStopPredictionsCard({ routeId, direction, stopCode }: BusStopPredict
             aria-label={`${directionLabel} arrivals for route ${routeId} at stop ${stopCode}`}
             {...accessibilityProps}
         >
-            <header className="flex flex-wrap items-baseline justify-between gap-2">
-                <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
-                        {stopCode} - {directionLabel} arrivals
-                    </p>
-                </div>
-            </header>
+            <BusStopCardHeader busStopCode={stopCode} />
+            <p className="mt-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
+                {directionLabel} arrivals
+            </p>
 
             {error ? (
                 <div


### PR DESCRIPTION
This pull request introduces a new `BusStopCardHeader` component to improve the display of bus stop information and refactors the `BusStopPredictionsCard` to use this new header. The main goal is to provide a more informative and visually consistent header for bus stop cards, including loading states and error handling.

**Component extraction and UI improvements:**

* Added a new `BusStopCardHeader` component in `BusStopCardHeader.tsx` that fetches and displays bus stop details, shows loading skeletons, and handles errors gracefully.
* Refactored `BusStopPredictionsCard.tsx` to use the new `BusStopCardHeader` component for displaying bus stop information, replacing the previous inline header implementation. [[1]](diffhunk://#diff-47132a117309074e2332bcf6cf8e973fc4c38b159dd8b706ed4681ebadaed07cR3-R4) [[2]](diffhunk://#diff-47132a117309074e2332bcf6cf8e973fc4c38b159dd8b706ed4681ebadaed07cL93-L99)

<img width="612" height="806" alt="image" src="https://github.com/user-attachments/assets/cf4710d5-c9ff-4053-b433-ddaa215ed10a" />
