### PR TITLE
create card component and adjust padding for mobile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,8 @@ import SystemTimeCard from './components/SystemTimeCard';
 
 function App() {
     return (
-        <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-12 text-slate-100">
-            <section className="w-full max-w-3xl space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 p-8 shadow-2xl shadow-slate-950/60 backdrop-blur">
+        <main className="flex min-h-screen items-center justify-center bg-slate-950 md:px-6 px-4 md:py-12 py-6 text-slate-100">
+            <section className="w-full max-w-3xl space-y-6 rounded-2xl border border-slate-800 bg-slate-900/50 md:p-8 p-4 shadow-2xl shadow-slate-950/60 backdrop-blur">
                 <header className="space-y-2">
                     <p className="text-sm uppercase tracking-[0.4em] text-slate-200">Where is 51B?</p>
                 </header>

--- a/frontend/src/components/BusRouteMap.tsx
+++ b/frontend/src/components/BusRouteMap.tsx
@@ -5,6 +5,7 @@ import { gql, useSubscription } from 'urql';
 
 import 'leaflet/dist/leaflet.css';
 
+import Card from './Card';
 import LiveRelativeTime from './LiveRelativeTime';
 
 import { escapeHtml } from '../utils/escapeHtml';
@@ -180,11 +181,7 @@ function BusRouteMap({ routeId }: BusRouteMapProps) {
         : {};
 
     return (
-        <section
-            className="rounded-xl border border-slate-800 bg-slate-900/80 p-6"
-            aria-label={`Live map for route ${routeId}`}
-            {...accessibilityProps}
-        >
+        <Card aria-label={`Live map for route ${routeId}`} {...accessibilityProps}>
             <header>
                 <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Live route map</p>
             </header>
@@ -276,7 +273,7 @@ function BusRouteMap({ routeId }: BusRouteMapProps) {
                     </span>
                 )}
             </footer>
-        </section>
+        </Card>
     );
 }
 

--- a/frontend/src/components/BusStopPredictionsCard.tsx
+++ b/frontend/src/components/BusStopPredictionsCard.tsx
@@ -1,6 +1,7 @@
 import { gql, useSubscription } from 'urql';
 
 import BusStopCardHeader from './BusStopCardHeader';
+import Card from './Card';
 
 const BUS_STOP_PREDICTIONS_SUBSCRIPTION = gql`
     subscription BusStopPredictions($routeId: String!, $direction: BusDirection!, $stopCode: String!) {
@@ -87,8 +88,7 @@ function BusStopPredictionsCard({ routeId, direction, stopCode }: BusStopPredict
         : {};
 
     return (
-        <section
-            className="rounded-xl border border-slate-800 bg-slate-900/80 p-6"
+        <Card
             aria-label={`${directionLabel} arrivals for route ${routeId} at stop ${stopCode}`}
             {...accessibilityProps}
         >
@@ -137,7 +137,7 @@ function BusStopPredictionsCard({ routeId, direction, stopCode }: BusStopPredict
                                   </div>
                                   <div className="text-right text-sm text-slate-300">
                                       <p className="font-medium">Vehicle {prediction.vehicleId || '?'}</p>
-                                      <p className="text-slate-400">ETA {formattedArrival}</p>
+                                      <p className="text-slate-400 md:text-base text-xs">ETA {formattedArrival}</p>
                                       {distance ? <p className="text-xs text-slate-500">{distance}</p> : null}
                                   </div>
                               </article>
@@ -145,7 +145,7 @@ function BusStopPredictionsCard({ routeId, direction, stopCode }: BusStopPredict
                       })
                     : null}
             </div>
-        </section>
+        </Card>
     );
 }
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,17 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+const BASE_CARD_CLASSNAMES = 'rounded-xl border border-slate-800 bg-slate-900/80 md:p-6 p-4';
+
+type CardProps = ComponentPropsWithoutRef<'section'>;
+
+function Card({ className, children, ...rest }: CardProps) {
+    const mergedClassName = className ? `${BASE_CARD_CLASSNAMES} ${className}` : BASE_CARD_CLASSNAMES;
+
+    return (
+        <section className={mergedClassName} {...rest}>
+            {children}
+        </section>
+    );
+}
+
+export default Card;

--- a/frontend/src/components/SystemTimeCard.tsx
+++ b/frontend/src/components/SystemTimeCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { gql, useSubscription } from 'urql';
 
+import Card from './Card';
 import LiveRelativeTime from './LiveRelativeTime';
 
 const SYSTEM_TIME_SUBSCRIPTION = gql`
@@ -81,18 +82,22 @@ function SystemTimeCard() {
 
     if (error) {
         return (
-            <div className="rounded-lg border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-200" role="alert">
-                <p className="font-medium">Subscription error</p>
-                <p>{error.message}</p>
-            </div>
+            <Card aria-label="System time">
+                <div
+                    className="rounded-lg border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-200"
+                    role="alert"
+                >
+                    <p className="font-medium">Subscription error</p>
+                    <p>{error.message}</p>
+                </div>
+            </Card>
         );
     }
 
     const isLoading = !displayTime;
 
     return (
-        <section
-            className="rounded-xl border border-slate-800 bg-slate-900/80 p-6"
+        <Card
             aria-label="System time"
             {...(isLoading ? { role: 'status' as const, 'aria-live': 'polite' as const, 'aria-busy': 'true' } : {})}
         >
@@ -131,7 +136,7 @@ function SystemTimeCard() {
                     <span className="sr-only">Synchronising clock</span>
                 </>
             )}
-        </section>
+        </Card>
     );
 }
 


### PR DESCRIPTION
This pull request refactors the UI components to improve code reuse and maintainability by introducing a new reusable `Card` component. Several existing components that previously used custom `<section>` elements with similar styling now use the new `Card` component, resulting in cleaner code and consistent styling. Minor responsive design improvements were also made.

**Component abstraction and code reuse:**
* Added a new reusable `Card` component in `frontend/src/components/Card.tsx` that wraps content in a styled section element and merges custom class names.
* Updated `BusRouteMap`, `BusStopPredictionsCard`, and `SystemTimeCard` components to use the new `Card` component instead of custom section markup, reducing duplication and centralizing card styling. [[1]](diffhunk://#diff-a558c94daa2e999bc79ccd38ba7102127760867fdc429b48a8b0676e4ec0fc9aR8) [[2]](diffhunk://#diff-a558c94daa2e999bc79ccd38ba7102127760867fdc429b48a8b0676e4ec0fc9aL183-R184) [[3]](diffhunk://#diff-a558c94daa2e999bc79ccd38ba7102127760867fdc429b48a8b0676e4ec0fc9aL279-R276) [[4]](diffhunk://#diff-47132a117309074e2332bcf6cf8e973fc4c38b159dd8b706ed4681ebadaed07cR4) [[5]](diffhunk://#diff-47132a117309074e2332bcf6cf8e973fc4c38b159dd8b706ed4681ebadaed07cL90-R91) [[6]](diffhunk://#diff-47132a117309074e2332bcf6cf8e973fc4c38b159dd8b706ed4681ebadaed07cL140-R148) [[7]](diffhunk://#diff-d44d8a926a8d6ccb1054f12ec3a95b9fb862e2d3eaa09cdaa0f3a77d5c2745d9R4) [[8]](diffhunk://#diff-d44d8a926a8d6ccb1054f12ec3a95b9fb862e2d3eaa09cdaa0f3a77d5c2745d9L84-R100) [[9]](diffhunk://#diff-d44d8a926a8d6ccb1054f12ec3a95b9fb862e2d3eaa09cdaa0f3a77d5c2745d9L134-R139)

**Responsive design improvements:**
* Improved responsive padding in the main app layout and card components by adding conditional `md:` classes for padding and spacing in `frontend/src/App.tsx` and the new `Card` component. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL7-R8) [[2]](diffhunk://#diff-5e1fda4ddb8adb886b9b3e6e9a7bc05938b3433de88a94e9e0d0a69bf3796bafR1-R17)
* Adjusted ETA text size in `BusStopPredictionsCard` to use responsive classes for better readability on different screen sizes.

<img width="462" height="879" alt="image" src="https://github.com/user-attachments/assets/ae145a6b-b7c0-4f62-81d2-2eb691338b4b" />

<img width="1115" height="937" alt="image" src="https://github.com/user-attachments/assets/1b32274c-397f-4cb1-bbb7-e8ac5acc9e57" />
